### PR TITLE
fixed wrong clone url

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ When the IP assigned, remember the IP address and press Ctrl+Q to exit
 
 Clone this repo
 ```
-$ git clone https://github.com/rbitia/aci-demos.git
+$ git clone https://github.com/Azure-Samples/virtual-kubelet-aci-burst.git
 ```
 
 Change the folder to the root of the source code
@@ -89,7 +89,7 @@ $ chmod u+x assignFQDNtoIP.sh
 $ ./assignFQDNtoIP.sh -g <myResourceGroup> -d <appName> -i <IP Address>
 ```
 
-Edit the values.yaml file and replace all `<host name>` with the FQDN name in pervious step.
+Edit the values.yaml file and replace all `<host name>` with the FQDN name in previous step.
 ```
 $ vim ./charts/fr-demo/values.yaml 
 ```


### PR DESCRIPTION
> Clone this repo
> `$ git clone https://github.com/rbitia/aci-demos.git`

That's the wrong repo. Shouldn't that be https://github.com/Azure-Samples/virtual-kubelet-aci-burst.git ?

> Edit the values.yaml file and replace all <host name> with the FQDN name in pervious step.
> `$ vim ./charts/fr-demo/values.yaml`

The string `host name` does not appear in that file. There are multiple domains.  It's not clear what to use.

Changing which url to clone fixes this. (And fixes the incorrect `cd` command)

I threw in a spelling mistake correction as well.